### PR TITLE
fix: fix script src to d3.min.js

### DIFF
--- a/javascript/treemap.html
+++ b/javascript/treemap.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 
-<script src="d3.min.js"></script>
+<script src="node_modules/d3/dist/d3.min.js"></script>
 <script src="d3po.js"></script>
 
 <div id="exports"></div>


### PR DESCRIPTION
A detail to fix loading of d3.js in treemap.html example.